### PR TITLE
tweak @typescript-eslint/return-await

### DIFF
--- a/src/eslint/configuration.js
+++ b/src/eslint/configuration.js
@@ -120,7 +120,8 @@ const typescriptRules = {
   "@typescript-eslint/no-explicit-any": "off",
   "@typescript-eslint/no-misused-new": "error",
   "@typescript-eslint/await-thenable": "error",
-  "@typescript-eslint/return-await": "error",
+  "no-return-await": "off", // conflicts with @typescript-eslint/return-await
+  "@typescript-eslint/return-await": ["error", "always"],
   "@typescript-eslint/require-await": "error",
   "@typescript-eslint/no-throw-literal": "error",
   "@typescript-eslint/no-shadow": "error",


### PR DESCRIPTION
Related to #3 

Related resources

- https://github.com/goldbergyoni/nodebestpractices#-212-always-await-promises-before-returning-to-avoid-a-partial-stacktrace
- https://github.com/goldbergyoni/nodebestpractices/pull/758
- https://github.com/goldbergyoni/nodebestpractices/issues/737

close  #3 