### PR TITLE
Turn @typescript-eslint/no-explicit-any into error

### DIFF
--- a/src/eslint/configuration.js
+++ b/src/eslint/configuration.js
@@ -121,7 +121,7 @@ const typescriptRules = {
   "@typescript-eslint/restrict-plus-operands": "error",
   "@typescript-eslint/restrict-template-expressions": "error",
   "@typescript-eslint/no-floating-promises": "error",
-  "@typescript-eslint/no-explicit-any": "off",
+  "@typescript-eslint/no-explicit-any": "error",
   "@typescript-eslint/no-misused-new": "error",
   "@typescript-eslint/await-thenable": "error",
   "no-return-await": "off", // conflicts with @typescript-eslint/return-await


### PR DESCRIPTION
`any` is a less type-safe alternative to `unknown` (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#new-unknown-top-type).

On most places `any` can be substituted for `unknown` without further changes. For use-cases where `any` specifically is necessary we can turn the rule off. https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-explicit-any.md#when-not-to-use-it.