### PR TITLE
camelCase-only for variables

### DIFF
--- a/src/eslint/configuration.js
+++ b/src/eslint/configuration.js
@@ -154,6 +154,23 @@ const typescriptRules = {
   "@typescript-eslint/no-empty-function": "off",
   "dot-notation": "off", // can conflict with "@typescript-eslint/dot-notation"
   "@typescript-eslint/dot-notation": "error",
+  camelcase: "off", // can conflict with @typescript-eslint/naming-convention
+  "@typescript-eslint/naming-convention": [
+    "error",
+    {
+      selector: "default",
+      format: ["camelCase"],
+      leadingUnderscore: "allow",
+      trailingUnderscore: "allow",
+    },
+    {
+      selector: "variable",
+      format: ["camelCase"],
+      leadingUnderscore: "allow",
+      trailingUnderscore: "allow",
+    },
+    { selector: "typeLike", format: ["PascalCase"] },
+  ],
 }
 
 const baseExtends = ["eslint:recommended", "plugin:prettier/recommended"]


### PR DESCRIPTION
Slight tweak of https://github.com/typescript-eslint/typescript-eslint/blob/dc58ff5da99989510fdbbe5575a31acd320b1808/packages/eslint-plugin/src/rules/naming-convention.ts#L29 to allow for camelCase variables only.

I've ran this configuration in the following projects

- gitspiegel
- substrate-matrix-faucet
- command-bot
- github-issue-sync
- opstooling-js

And found that they're already conforming to the convention, so no changes would be needed for this.

Related to https://github.com/paritytech/gitspiegel/pull/96#discussion_r908294141 and https://github.com/paritytech/substrate-matrix-faucet/pull/150#discussion_r860900448.