### PR TITLE
Dropping no-restricted-imports rule

### DIFF
--- a/src/eslint/configuration.js
+++ b/src/eslint/configuration.js
@@ -37,7 +37,7 @@ const baseRules = {
   "import/first": "error",
   "import/newline-after-import": "error",
   "import/no-duplicates": ["error", { considerQueryString: true }],
-  "no-restricted-imports": ["error", { patterns: ["**/../**", ".."] }],
+  "no-restricted-imports": "off",
 
   // sonarjs
   "sonarjs/no-all-duplicated-branches": "error",


### PR DESCRIPTION
In https://github.com/paritytech/opstooling/pull/100, it was suggested
to disallow imports from upper levels. The rule was never respected as a
design choice, and mostly was either bypassed by absolute imports, or
disabled.
My opinion is that it would be better to drop it altogether, and allow
all imports.
